### PR TITLE
Support predicted grade calls w/ model ID and week

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,6 +50,15 @@ Sandbox.define('/v1/aggregates/8/data/{orgUnitId}','GET', function(req, res) {
     res.json(result);
 });
 
+// Predicted Grade of all users for Course - NEW ROUTE - UPDATED TO INCLUDE MODEL ID AND WEEK
+Sandbox.define('/v1/aggregates/8/data/{orgUnitId}/{activemodelId}/{predictedweek}','GET', function(req, res) {
+    var result = generatePredictedGradesData(req.params.orgUnitId);
+
+    res.type('application/json');
+    res.status(200);
+    res.json(result);
+});
+
 // Threads started
 Sandbox.define('/v1/aggregates/15/data/{orgUnitId}','GET', function(req, res) {
     var dates = utils.parseDates(req.query.startTime, req.query.endTime);


### PR DESCRIPTION
When the trial sites in prod got upgraded to 10.6.5, Class Engagement broke because the sandboxes (very similar to this one) didn't understand routes that include the active model ID and week for predicted grades (due to @csilcock 's change: https://github.com/Brightspace/insights-class-insights/commit/3b220b7a131aac5e0add900706c1b6f052c84c88).

This is the easiest way I could think of to fix it, since we don't really care about model and week with mock data anyway. Tested on a trial site and it seems to work. Thought I should make the same change here in case anyone ever clones this repo again. If anyone has better suggestions I am also open to that.

@AlexBedley
